### PR TITLE
履歴（検索）の部品を作成する

### DIFF
--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,13 +1,86 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+
+import { api } from '../api.ts';
+
+import { Data } from '../types/api.ts';
+
+type Order = {
+  keyName: 'balance_type' | 'date' | 'item' | 'amount';
+  order: 'asc' | 'desc';
+};
 
 import HouseholdAccountFilter from './HouseholdAccountFilter.tsx';
 import HouseholdAccounts from './HouseholdAccounts.tsx';
 
 const History: React.FC = () => {
+  const [totalBalance, setTotalBalance] = useState(0);
+  const [householdAccounts, setHouseholdAccounts] = useState<Data[]>([]);
+  const [order, setOrder] = useState<Order>({
+    keyName: 'date',
+    order: 'desc',
+  });
+
+  const sortHouseholdAccounts = (keyName: Order['keyName']) => {
+    const prevOrder = order.order;
+    const nextOrder: Order['order'] = (() => {
+      if (keyName !== order.keyName) return 'desc';
+      return prevOrder === 'asc' ? 'desc' : 'asc';
+    })();
+    const sortedData = [...householdAccounts].sort((a, b) => {
+      const isAsc = nextOrder === 'asc';
+      switch (keyName) {
+        case 'item':
+        case 'balance_type':
+          return isAsc
+            ? a[keyName].localeCompare(b[keyName])
+            : b[keyName].localeCompare(a[keyName]);
+        case 'date':
+          return isAsc
+            ? new Date(a.date).getTime() - new Date(b.date).getTime()
+            : new Date(b.date).getTime() - new Date(a.date).getTime();
+        case 'amount':
+          return isAsc
+            ? (a.balance_type === 'expense' ? -a[keyName] : a[keyName]) -
+                (b.balance_type === 'expense' ? -b[keyName] : b[keyName])
+            : (b.balance_type === 'expense' ? -b[keyName] : b[keyName]) -
+                (a.balance_type === 'expense' ? -a[keyName] : a[keyName]);
+        default:
+          return 0;
+      }
+    });
+    setHouseholdAccounts(sortedData);
+    setOrder({ keyName, order: nextOrder });
+  };
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await api('GET /data');
+      data.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+      );
+      setHouseholdAccounts(data);
+      const totalBalance = data.reduce((acc, cur) => {
+        return cur.balance_type === 'expense'
+          ? acc - cur.amount
+          : acc + cur.amount;
+      }, 0);
+      setTotalBalance(totalBalance);
+    })();
+  }, []);
+
   return (
     <>
+      <div className="p-8 flex justify-center">
+        <h2 className="text-xl font-bold">合計金額: {totalBalance}円</h2>
+      </div>
       <HouseholdAccountFilter />
-      <HouseholdAccounts />
+      <HouseholdAccounts
+        householdAccounts={householdAccounts}
+        keyName={order.keyName}
+        sortHouseholdAccounts={(keyName: Order['keyName']) =>
+          sortHouseholdAccounts(keyName)
+        }
+      />
     </>
   );
 };

--- a/src/components/HouseholdAccountFilter.tsx
+++ b/src/components/HouseholdAccountFilter.tsx
@@ -1,7 +1,78 @@
-import React from 'react';
+import React, { useState } from 'react';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import { ja } from 'date-fns/locale/ja';
+
+registerLocale('ja', ja);
 
 const HouseholdAccountFilter: React.FC = () => {
-  return <></>;
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState(
+    new Date().toLocaleDateString('ja-JP').split('/').join('-')
+  );
+  const [category, setCategory] = useState('');
+  const changeStartDate = (value: Date | null) => {
+    const date = value
+      ? value.toLocaleDateString('ja-JP').split('/').join('-')
+      : '';
+    setStartDate(date);
+    if (value && new Date(value) > new Date(endDate)) {
+      setEndDate(date);
+    }
+  };
+  const changeEndDate = (value: Date | null) => {
+    if (!value) return;
+    const date = value.toLocaleDateString('ja-JP').split('/').join('-');
+    setEndDate(date);
+    if (new Date(value) < new Date(startDate)) {
+      setStartDate(date);
+    }
+  };
+
+  return (
+    <div className="flex p-8">
+      <div className="w-1/2">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          種別
+        </label>
+        <select
+          className="shadow appearance-none border rounded w-1/2 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          onChange={(e) => setCategory(e.target.value)}
+          value={category}
+        >
+          <option value="">収入/支出</option>
+          <option value="income">収入のみ</option>
+          <option value="expense">支出のみ</option>
+        </select>
+      </div>
+      <div className="w-1/2">
+        <label className="block text-gray-700 text-sm font-bold mb-2">
+          対象日
+        </label>
+        <div className="flex items-center">
+          <DatePicker
+            locale="ja"
+            dateFormat="yyyy/MM/dd"
+            dateFormatCalendar="yyyy年 MM月"
+            selected={startDate ? new Date(startDate) : null}
+            isClearable={true}
+            maxDate={new Date()}
+            onChange={(startDate) => changeStartDate(startDate)}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          />
+          <span className="mx-2 text-center">〜</span>
+          <DatePicker
+            locale="ja"
+            dateFormat="yyyy/MM/dd"
+            dateFormatCalendar="yyyy年 MM月"
+            selected={new Date(endDate)}
+            maxDate={new Date()}
+            onChange={(endDate) => changeEndDate(endDate)}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default HouseholdAccountFilter;

--- a/src/components/HouseholdAccounts.tsx
+++ b/src/components/HouseholdAccounts.tsx
@@ -1,6 +1,4 @@
-import React, { useState, useEffect } from 'react';
-
-import { api } from '../api.ts';
+import React from 'react';
 
 import { Data } from '../types/api.ts';
 
@@ -9,65 +7,17 @@ type Order = {
   order: 'asc' | 'desc';
 };
 
-const HouseholdAccounts: React.FC = () => {
-  const [householdAccounts, setHouseholdAccounts] = useState<Data[]>([]);
-  const [totalBalance, setTotalBalance] = useState(0);
-  const [order, setOrder] = useState<Order>({ keyName: 'date', order: 'desc' });
+type Props = {
+  householdAccounts: Data[];
+  sortHouseholdAccounts: (keyName: Order['keyName']) => void;
+};
 
-  useEffect(() => {
-    (async () => {
-      const { data } = await api('GET /data');
-      data.sort(
-        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-      );
-      setHouseholdAccounts(data);
-
-      const totalBalance = data.reduce((acc, cur) => {
-        return cur.balance_type === 'expense'
-          ? acc - cur.amount
-          : acc + cur.amount;
-      }, 0);
-      setTotalBalance(totalBalance);
-    })();
-  }, []);
-
-  const sortHouseholdAccounts = (keyName: Order['keyName']) => {
-    const prevOrder = order.order;
-    const nextOrder: Order['order'] = (() => {
-      if (keyName !== order.keyName) return 'desc';
-      return prevOrder === 'asc' ? 'desc' : 'asc';
-    })();
-    const sortedData = [...householdAccounts].sort((a, b) => {
-      const isAsc = nextOrder === 'asc';
-      switch (keyName) {
-        case 'item':
-        case 'balance_type':
-          return isAsc
-            ? a[keyName].localeCompare(b[keyName])
-            : b[keyName].localeCompare(a[keyName]);
-        case 'date':
-          return isAsc
-            ? new Date(a.date).getTime() - new Date(b.date).getTime()
-            : new Date(b.date).getTime() - new Date(a.date).getTime();
-        case 'amount':
-          return isAsc
-            ? (a.balance_type === 'expense' ? -a[keyName] : a[keyName]) -
-                (b.balance_type === 'expense' ? -b[keyName] : b[keyName])
-            : (b.balance_type === 'expense' ? -b[keyName] : b[keyName]) -
-                (a.balance_type === 'expense' ? -a[keyName] : a[keyName]);
-        default:
-          return 0;
-      }
-    });
-    setHouseholdAccounts(sortedData);
-    setOrder({ keyName, order: nextOrder });
-  };
-
+const HouseholdAccounts: React.FC<Props & { keyName: string }> = ({
+  householdAccounts,
+  sortHouseholdAccounts,
+}) => {
   return (
     <>
-      <div className="p-8 flex justify-center">
-        <h2 className="text-xl font-bold">合計金額: {totalBalance}円</h2>
-      </div>
       <div className="overflow-x-auto p-8">
         <table className="min-w-full bg-white border border-gray-200">
           <thead>


### PR DESCRIPTION
### refs
-  #8 
### 対応内容
- 履歴の検索フォームの部品を作成した
   - 収支の種別、対象日の入力フォームを作成した
   - 収支の種別を選択できるようにした
   - 対象日を選択できるようにした
- 履歴の一覧表示で使用していたものを親コンポーネントに記述した

### 確認内容
- 作業内容が反映されていること

### notes
- close #8 